### PR TITLE
Add language property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Geocoder::make('address')
     ->countries(string|array|Closure $countries) 
     // Like the one before but only one country.
     ->country(string|Closure $country)
+    // Specify the language to use for the results (default 'en').
+    ->language(string|Closure $language)
     // Specify whether the Geocoding API should attempt approximate, as well as exact, matching when performing searches (default true).
     ->fuzzyMatch(bool|Closure $fuzzyMatch = true)
     // Limit the maximum number of results to show (default 5).

--- a/resources/views/forms/components/geocoder.blade.php
+++ b/resources/views/forms/components/geocoder.blade.php
@@ -30,6 +30,7 @@
         accessToken: @Js($getAccessToken()),
         clearAndBlurOnEsc: @js($getClearAndBlurOnEsc(), JSON_THROW_ON_ERROR),
         countries: @Js($getCountries()),
+        language: @Js($getLanguage()),
         fuzzyMatch: @Js($getFuzzyMatch()),
         limit: @Js($getLimit()),
         minLength: @Js($getMinLength()),

--- a/resources/views/forms/components/geocoder.blade.php
+++ b/resources/views/forms/components/geocoder.blade.php
@@ -26,17 +26,19 @@
     <div
       x-load
       x-load-src="{{ FilamentAsset::getAlpineComponentSrc('geocoder', 'speniti/filament-mapbox') }}"
-      x-data="geocoder($wire.{{ $applyStateBindingModifiers("\$entangle('{$getStatePath()}')") }}, {
-        accessToken: @Js($getAccessToken()),
-        clearAndBlurOnEsc: @js($getClearAndBlurOnEsc(), JSON_THROW_ON_ERROR),
-        countries: @Js($getCountries()),
-        language: @Js($getLanguage()),
-        fuzzyMatch: @Js($getFuzzyMatch()),
-        limit: @Js($getLimit()),
-        minLength: @Js($getMinLength()),
-        placeholder: @Js($getPlaceholder()),
-        types: @Js($getTypes()),
-    }, @js($isDisabled(), JSON_THROW_ON_ERROR))"
+      x-data="geocoder($wire.{{ $applyStateBindingModifiers("\$entangle('{$getStatePath()}')") }},
+      @js(array_filter([
+        'accessToken' => $getAccessToken(),
+        'clearAndBlurOnEsc' => $getClearAndBlurOnEsc(),
+        'countries' => $getCountries(),
+        'language' => $getLanguage(),
+        'fuzzyMatch' => $getFuzzyMatch(),
+        'limit' => $getLimit(),
+        'minLength' => $getMinLength(),
+        'placeholder' => $getPlaceholder(),
+        'types' => $getTypes(),
+      ], fn($value) => !is_null($value) && $value !== '' && $value !== []), JSON_THROW_ON_ERROR),
+      @js($isDisabled(), JSON_THROW_ON_ERROR))"
       x-ignore
       wire:ignore
     ></div>

--- a/src/Forms/Fields/Geocoder.php
+++ b/src/Forms/Fields/Geocoder.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use League\ISO3166\Exception\DomainException;
 use League\ISO3166\ISO3166;
+use League\ISO639\
 use Peniti\FilamentMapbox\Geocoder\FeatureType;
 
 class Geocoder extends Field
@@ -24,6 +25,8 @@ class Geocoder extends Field
     private bool|Closure|null $clearAndBlurOnEsc = null;
 
     private string|Closure|null $countries = null;
+
+    private string|Closure|null $language = null;
 
     private bool|Closure|null $fuzzyMatch = null;
 
@@ -77,6 +80,14 @@ class Geocoder extends Field
         return $this->countries($country);
     }
 
+    /** @param string|Closure(mixed...):string $language */
+    public function language(string|Closure $language): self
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
     /** @param bool|Closure(mixed...):bool $fuzzyMatch */
     public function fuzzyMatch(bool|Closure $fuzzyMatch = true): self
     {
@@ -110,6 +121,11 @@ class Geocoder extends Field
         assert(is_string($countries) || is_null($countries));
 
         return $countries;
+    }
+
+    public function getLanguage(): ?string
+    {
+        return $this->language;
     }
 
     public function getFuzzyMatch(): ?bool

--- a/src/Forms/Fields/Geocoder.php
+++ b/src/Forms/Fields/Geocoder.php
@@ -25,9 +25,9 @@ class Geocoder extends Field
 
     private string|Closure|null $countries = null;
 
-    private string|Closure|null $language = null;
-
     private bool|Closure|null $fuzzyMatch = null;
+
+    private string|Closure|null $language = null;
 
     private int|Closure|null $limit = null;
 
@@ -79,14 +79,6 @@ class Geocoder extends Field
         return $this->countries($country);
     }
 
-    /** @param string|Closure(mixed...):string $language */
-    public function language(string|Closure $language): self
-    {
-        $this->language = $language;
-
-        return $this;
-    }
-
     /** @param bool|Closure(mixed...):bool $fuzzyMatch */
     public function fuzzyMatch(bool|Closure $fuzzyMatch = true): self
     {
@@ -122,11 +114,6 @@ class Geocoder extends Field
         return $countries;
     }
 
-    public function getLanguage(): ?string
-    {
-        return $this->language;
-    }
-
     public function getFuzzyMatch(): ?bool
     {
         $fuzzyMatch = $this->evaluate($this->fuzzyMatch);
@@ -134,6 +121,15 @@ class Geocoder extends Field
         assert(is_bool($fuzzyMatch) || is_null($fuzzyMatch));
 
         return $fuzzyMatch;
+    }
+
+    public function getLanguage(): ?string
+    {
+        $language = $this->evaluate($this->language);
+
+        assert(is_string($language));
+
+        return $language;
     }
 
     public function getLimit(): ?int
@@ -161,6 +157,14 @@ class Geocoder extends Field
         assert(is_string($types));
 
         return $types;
+    }
+
+    /** @param string|Closure(mixed...):string $language */
+    public function language(string|Closure $language): self
+    {
+        $this->language = $language;
+
+        return $this;
     }
 
     /** @param int|Closure(mixed...):int $limit */

--- a/src/Forms/Fields/Geocoder.php
+++ b/src/Forms/Fields/Geocoder.php
@@ -127,7 +127,7 @@ class Geocoder extends Field
     {
         $language = $this->evaluate($this->language);
 
-        assert(is_string($language));
+        assert(is_string($language) || is_null($language));
 
         return $language;
     }

--- a/src/Forms/Fields/Geocoder.php
+++ b/src/Forms/Fields/Geocoder.php
@@ -25,7 +25,7 @@ class Geocoder extends Field
 
     private string|Closure|null $countries = null;
 
-    private string|Closure|null $language = 'en';
+    private string|Closure|null $language = null;
 
     private bool|Closure|null $fuzzyMatch = null;
 

--- a/src/Forms/Fields/Geocoder.php
+++ b/src/Forms/Fields/Geocoder.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use League\ISO3166\Exception\DomainException;
 use League\ISO3166\ISO3166;
-use League\ISO639\
 use Peniti\FilamentMapbox\Geocoder\FeatureType;
 
 class Geocoder extends Field
@@ -26,7 +25,7 @@ class Geocoder extends Field
 
     private string|Closure|null $countries = null;
 
-    private string|Closure|null $language = null;
+    private string|Closure|null $language = 'en';
 
     private bool|Closure|null $fuzzyMatch = null;
 

--- a/tests/Feature/Forms/Fields/GeocoderTest.php
+++ b/tests/Feature/Forms/Fields/GeocoderTest.php
@@ -76,32 +76,32 @@ describe(Geocoder::class, static function () {
 
     it('clears when the esc key is pressed', function () {
         livewire(GeocoderClearAndBlurOnEsc::class)
-            ->assertSee('clearAndBlurOnEsc: true,');
+            ->assertSee('\u0022clearAndBlurOnEsc\u0022:true,');
     });
 
     it('limits results to a specified country or countries', function () {
         livewire(GeocoderCountries::class)
-            ->assertSee("countries: 'IT, US',", escape: false);
+            ->assertSee("\u0022countries\u0022:\u0022IT", escape: false);
     });
 
     it('attempts approximate, as well as exact, matching', function () {
         livewire(GeocoderFuzzyMatch::class)
-            ->assertSee('fuzzyMatch: true,');
+            ->assertSee('\u0022fuzzyMatch\u0022:true');
     });
 
     it('limits the number of results returned', function () {
         livewire(GeocoderLimit::class)
-            ->assertSee('limit: 10,');
+            ->assertSee('\u0022limit\u0022:10');
     });
 
     it('set the minimum number of characters required to trigger a search', function () {
         livewire(GeocoderMinLength::class)
-            ->assertSee('minLength: 3,');
+            ->assertSee('\u0022minLength\u0022:3');
     });
 
     it('filters results to match specified types', function () {
         livewire(GeocoderTypes::class)
-            ->assertSee("types: 'country, region',", escape: false);
+            ->assertSee("\u0022types\u0022:\u0022country, region\u0022", escape: false);
     });
 
     it('can be required', function () {


### PR DESCRIPTION
The Mapbox Geocoding API supports a [language property](https://docs.mapbox.com/api/search/geocoding/#forward-geocoding-with-search-text-input) to return results in the appropriate language. This simple PR adds support for that.

Dutch (`nl`):

```php
Geocoder::make('address')
 ->label('Adres')
 ->language('nl')
```
<img width="315" height="201" alt="Screenshot 2025-10-15 at 14 12 05" src="https://github.com/user-attachments/assets/3b6cce3b-0f90-4436-a0dc-3473f7a7e8a3" />
